### PR TITLE
Codemod for v7 upgrade

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,9 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: 'main'
-          fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
           node-version: 14.x

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ WebdriverIO Codemod [![Test](https://github.com/webdriverio/protractor-codemod/a
 This project contains various codemods to help migrating from either one major WebdriverIO version to another or from a specific framework to WebdriverIO. It can be used with [jscodeshift](https://www.npmjs.com/package/jscodeshift) and currently supports the following migrations:
 
 - [x] Protractor ▶️&nbsp; WebdriverIO (see [migration guide](https://webdriver.io/docs/protractor-migration))
+- [x] v6 ▶️&nbsp; v7 (see [migration guide](https://webdriver.io/docs/v7-migration))
 - [ ] _more will eventually follow, let us know which ones you would like to see_
 
 If you run into any issues during your migration please [let us know](https://github.com/webdriverio/codemod/discussions/new).

--- a/protractor/index.js
+++ b/protractor/index.js
@@ -734,5 +734,5 @@ module.exports = function transformer(file, api) {
         )
     })
 
-    return root.toSource();
+    return root.toSource()
 }

--- a/test/__fixtures__/v7/source/compilerFunctions.js
+++ b/test/__fixtures__/v7/source/compilerFunctions.js
@@ -1,0 +1,30 @@
+exports.config = {
+    cucumberOpts: {
+        requireModule: [
+            () => {
+                console.log('foo');
+                require('ts-node').register({ transpileOnly: true });
+                console.log('bar');
+            }
+        ]
+    },
+
+    jasmineOpts: {
+        requires: [
+            () => require('@babel/register')({
+                ignore: []
+            })
+        ]
+    },
+
+    mochaOpts: {
+        require: [
+            async function () {
+                require('tsconfig-paths').register({
+                    baseUrl,
+                    paths: tsConfig.compilerOptions.paths
+                })
+            }
+        ]
+    }
+}

--- a/test/__fixtures__/v7/source/spec.js
+++ b/test/__fixtures__/v7/source/spec.js
@@ -1,2 +1,42 @@
-import { Given, When, Then } from 'cucumber'
-const { Given2, When2, Then2 } = require('cucumber')
+import { Given, When, Then } from 'cucumber';
+const { Given2, When2, Then2 } = require('cucumber');
+
+exports.config = {
+    mochaOpts: {
+        ui: 'bdd',
+        timeout: 5000,
+        require: [
+            '@babel/register',
+            'ts-node/register',
+            '/foo/bar',
+            'tsconfig-paths/register',
+            [
+                '@babel/register',
+                {
+                    rootMode: 'upward',
+                    ignore: ['node_modules']
+                }
+            ]
+        ]
+    },
+
+    jasmineOpts: {
+        requires: [
+            '@babel/register',
+            'ts-node/register',
+            ['tsconfig-paths/register', {
+                foo: 'bar'
+            }]
+        ]
+    },
+
+    cucumberOpts: {
+        requireModule: [
+            '@babel/register',
+            ['ts-node/register', {
+                bar: 'foo'
+            }],
+            'tsconfig-paths/register'
+        ]
+    }
+}

--- a/test/__fixtures__/v7/source/spec.js
+++ b/test/__fixtures__/v7/source/spec.js
@@ -1,0 +1,2 @@
+import { Given, When, Then } from 'cucumber'
+const { Given2, When2, Then2 } = require('cucumber')

--- a/test/__fixtures__/v7/transformed/compilerFunctions.js
+++ b/test/__fixtures__/v7/transformed/compilerFunctions.js
@@ -1,0 +1,33 @@
+exports.config = {
+    cucumberOpts: {
+        requireModule: [() => {
+            console.log('foo');
+            console.log('bar');
+        }]
+    },
+
+    autoCompileOpts: {
+        autoCompile: true,
+
+        tsNodeOpts: {
+            transpileOnly: true
+        },
+
+        tsConfigPathsOpts: {
+            baseUrl,
+            paths: tsConfig.compilerOptions.paths
+        },
+
+        babelOpts: {
+            ignore: []
+        }
+    },
+
+    jasmineOpts: {
+        requires: []
+    },
+
+    mochaOpts: {
+        require: [async function () {}]
+    }
+}

--- a/test/__fixtures__/v7/transformed/spec.js
+++ b/test/__fixtures__/v7/transformed/spec.js
@@ -1,2 +1,35 @@
 import { Given, When, Then } from "@cucumber/cucumber";
-const { Given2, When2, Then2 } = require("@cucumber/cucumber")
+const { Given2, When2, Then2 } = require("@cucumber/cucumber");
+
+exports.config = {
+    mochaOpts: {
+        ui: 'bdd',
+        timeout: 5000,
+        require: ['/foo/bar']
+    },
+
+    autoCompileOpts: {
+        autoCompile: true,
+
+        babelOpts: {
+            rootMode: 'upward',
+            ignore: ['node_modules']
+        },
+
+        tsConfigPathsOpts: {
+            foo: 'bar'
+        },
+
+        tsNodeOpts: {
+            bar: 'foo'
+        }
+    },
+
+    jasmineOpts: {
+        requires: []
+    },
+
+    cucumberOpts: {
+        requireModule: []
+    }
+}

--- a/test/__fixtures__/v7/transformed/spec.js
+++ b/test/__fixtures__/v7/transformed/spec.js
@@ -1,0 +1,2 @@
+import { Given, When, Then } from "@cucumber/cucumber";
+const { Given2, When2, Then2 } = require("@cucumber/cucumber")

--- a/test/runner.js
+++ b/test/runner.js
@@ -25,7 +25,8 @@ const frameworkTests = {
         ['./failing_anythingProtractor.js']
     ],
     v7: [
-        ['./spec.js', './spec.js']
+        ['./spec.js', './spec.js'],
+        ['./compilerFunctions.js', './compilerFunctions.js']
     ]
 }
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -66,11 +66,10 @@ async function runTest (framework, tests) {
 
         expect(sourceFileContent).toEqual(desiredFileContent)
     }
-
-    shell.rm('-r', path.join(__dirname, 'testdata'))
 }
 
 ;(async () => {
+    const teardown = () => shell.rm('-r', path.join(__dirname, 'testdata'))
     const testsToRun = process.argv.length === 3
         ? { [process.argv[2]]: frameworkTests[process.argv[2]] }
         : frameworkTests
@@ -78,7 +77,7 @@ async function runTest (framework, tests) {
         console.log('========================')
         console.log(`Run tests for ${framework}`)
         console.log('========================\n')
-        await runTest(framework, tests)
+        await runTest(framework, tests).finally(teardown)
     }
 })().then(
     () => console.log('Tests passed ✅'),

--- a/test/runner.js
+++ b/test/runner.js
@@ -23,6 +23,9 @@ const frameworkTests = {
         ['./failing_submit.js'],
         ['./failing_clone.js'],
         ['./failing_anythingProtractor.js']
+    ],
+    v7: [
+        ['./spec.js', './spec.js']
     ]
 }
 
@@ -63,10 +66,15 @@ async function runTest (framework, tests) {
 
         expect(sourceFileContent).toEqual(desiredFileContent)
     }
+
+    shell.rm('-r', path.join(__dirname, 'testdata'))
 }
 
 ;(async () => {
-    for (const [framework, tests] of Object.entries(frameworkTests)) {
+    const testsToRun = process.argv.length === 3
+        ? { [process.argv[2]]: frameworkTests[process.argv[2]] }
+        : frameworkTests
+    for (const [framework, tests] of Object.entries(testsToRun)) {
         console.log('========================')
         console.log(`Run tests for ${framework}`)
         console.log('========================\n')
@@ -76,8 +84,6 @@ async function runTest (framework, tests) {
     () => console.log('Tests passed ✅'),
     (err) => (error = err)
 ).then(() => {
-    shell.rm('-r', path.join(__dirname, 'testdata'))
-
     if (error) {
         delete error.matcherResult
         console.warn(error)

--- a/v7/constants.js
+++ b/v7/constants.js
@@ -3,3 +3,9 @@ exports.OBSOLETE_REQUIRE_MODULES = [
     'ts-node/register',
     'tsconfig-paths/register'
 ]
+
+exports.COMPILER_OPTS_MAPPING = {
+    '@babel/register': 'babelOpts',
+    'ts-node/register': 'tsNodeOpts',
+    'tsconfig-paths/register': 'tsConfigPathsOpts'
+}

--- a/v7/constants.js
+++ b/v7/constants.js
@@ -1,0 +1,5 @@
+exports.OBSOLETE_REQUIRE_MODULES = [
+    '@babel/register',
+    'ts-node/register',
+    'tsconfig-paths/register'
+]

--- a/v7/index.js
+++ b/v7/index.js
@@ -1,0 +1,30 @@
+module.exports = function transformer(file, api) {
+    const j = api.jscodeshift;
+    const root = j(file.source);
+    j.file = file
+
+    /**
+     * transforms imports from `require('cucumber')` to `require('@cucumber/cucumber')`
+     */
+    root.find(j.CallExpression, {
+        callee: { name: 'require' },
+        arguments: [{
+            value: 'cucumber'
+        }]
+    }).replaceWith((path) => (
+        j.callExpression(
+            path.value.callee,
+            [j.literal('@cucumber/cucumber')]
+        )
+    ))
+    root.find(j.ImportDeclaration, {
+        source: { value: 'cucumber' }
+    }).replaceWith((path) => (
+        j.importDeclaration(
+            path.value.specifiers,
+            j.literal('@cucumber/cucumber')
+        )
+    ))
+
+    return root.toSource()
+}

--- a/v7/index.js
+++ b/v7/index.js
@@ -1,7 +1,12 @@
+const {
+    OBSOLETE_REQUIRE_MODULES
+} = require('./constants')
+
 module.exports = function transformer(file, api) {
     const j = api.jscodeshift;
     const root = j(file.source);
     j.file = file
+    let autoCompileOpts = {}
 
     /**
      * transforms imports from `require('cucumber')` to `require('@cucumber/cucumber')`
@@ -25,6 +30,84 @@ module.exports = function transformer(file, api) {
             j.literal('@cucumber/cucumber')
         )
     ))
+
+    /**
+     * remove compiler requires
+     */
+    root.find(j.Property)
+        .filter((path) => (
+            path.value.key && (
+                path.value.key.name === 'require' ||
+                path.value.key.name === 'requires' ||
+                path.value.key.name === 'requireModule'
+            )
+        ))
+        .replaceWith((path) => {
+            return j.objectProperty(
+                j.identifier(path.value.key.name),
+                j.arrayExpression(path.value.value.elements.filter((value) => {
+                    let importName
+
+                    if (value.type === 'Literal') {
+                        importName = value.value
+                    } else if (value.type === 'ArrayExpression') {
+                        importName = value.elements[0].value
+
+                        const compileOptsName = importName === '@babel/register'
+                            ? 'babelOpts'
+                            : importName === 'ts-node/register'
+                                ? 'tsNodeOpts'
+                                : 'tsConfigPathsOpts'
+                        autoCompileOpts[compileOptsName] = value.elements[1].properties
+                    } else {
+                        throw new Error(`Unexpected require input ${value.type}`)
+                    }
+                    return !OBSOLETE_REQUIRE_MODULES.includes(importName)
+                }))
+            )
+        })
+
+    /**
+     * update config with compiler opts
+     */
+    let wasReplaced = false
+    root.find(j.Property)
+        .filter((path) => (
+            path.value.key && (
+                path.value.key.name === 'mochaOpts' ||
+                path.value.key.name === 'jasmineOpts' ||
+                path.value.key.name === 'jasmineNodeOpts' ||
+                path.value.key.name === 'cucumberOpts'
+            )
+        ))
+        .replaceWith((path) => {
+            if (wasReplaced) {
+                return path.value
+            }
+
+            wasReplaced = true
+            return [
+                path.value,
+                ...(Object.keys(autoCompileOpts).length
+                    ? [j.objectProperty(
+                        j.identifier('autoCompileOpts'),
+                        j.objectExpression([
+                            j.property(
+                                'init',
+                                j.identifier('autoCompile'),
+                                j.literal(true)
+                            ),
+                            ...Object.entries(autoCompileOpts).map(([propName, properties]) => j.property(
+                                'init',
+                                j.identifier(propName),
+                                j.objectExpression(properties)
+                            ))
+                        ])
+                    )]
+                    : []
+                )
+            ]
+        })
 
     return root.toSource()
 }


### PR DESCRIPTION
This patch will allow to upgrade from v6 to v7 with a single jscodeshift command.

Missing mods:
- [x] removal of `ts-node/register`, `tsconfig-paths/register` or `@babel/register` from config

⚠️ __work in progress__