### PR TITLE
Override os line endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ If you use TypeScript make sure you apply a different parser as parameter, e.g.:
 $ npx jscodeshift -t ./node_modules/@wdio/codemod/protractor --parser=tsx ./e2e/*.ts
 ```
 
+If you use a different line terminator from your os, you can override it as parameter, e.g.:
+
+```sh
+$ npx jscodeshift -t ./node_modules/@wdio/codemod/async --printOptions='{\"lineTerminator\":\"\n\"}' ./e2e/
+```
+
 You can transform tests as well as config files, e.g.:
 
 ![Codemod Usage Example][example]

--- a/async/index.js
+++ b/async/index.js
@@ -515,5 +515,5 @@ module.exports = function transformer(file, api, opts) {
 
 	compilers.update(j, root, auto_compile_opts, opts);
 
-	return root.toSource();
+	return root.toSource(opts.printOptions);
 }

--- a/protractor/index.js
+++ b/protractor/index.js
@@ -873,5 +873,5 @@ module.exports = function transformer(file, api, opts) {
     })
 
     compilers.update(j, root, autoCompileOpts, opts)
-    return root.toSource()
+    return root.toSource(opts.printOptions)
 }

--- a/v6/index.js
+++ b/v6/index.js
@@ -114,5 +114,5 @@ module.exports = function transformer(file, api, opts) {
         }))
     ))
 
-    return root.toSource()
+    return root.toSource(opts.printOptions)
 }

--- a/v7/index.js
+++ b/v7/index.js
@@ -29,5 +29,5 @@ module.exports = function transformer(file, api, opts) {
     ))
 
     compilers.update(j, root, autoCompileOpts, opts)
-    return root.toSource()
+    return root.toSource(opts.printOptions)
 }


### PR DESCRIPTION
New feature : If you use a different line terminator from your os, you can override it as parameter.
https://github.com/benjamn/recast/blob/52a7ec3eaaa37e78436841ed8afc948033a86252/lib/options.js#L21