### PR TITLE
Document async codemod dependency on v7.9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project contains various codemods to help migrating from either one major W
 - [x] v6 ▶️&nbsp; v7 (see [migration guide](https://webdriver.io/docs/v7-migration))
 - [x] Protractor ▶️&nbsp; WebdriverIO (see [migration guide](https://webdriver.io/docs/protractor-migration))
 - [x] Sync ▶️&nbsp; Async (see [migration guide](https://webdriver.io/docs/async-migration))
+  - Note: This codemod depends on the [proxying of chained async calls](https://webdriver.io/blog/2021/07/28/sync-api-deprecation/) added in v7.9
 - [ ] _more will eventually follow, let us know which ones you would like to see_
 
 If you run into any issues during your migration please [let us know](https://github.com/webdriverio/codemod/discussions/new).


### PR DESCRIPTION
@christian-bromann: This pull request documents the async codemod's dependency on WebDriver 7.9+, as discussed in https://github.com/webdriverio/codemod/issues/89#issuecomment-1445448642.