### PR TITLE
ci: Update Expense Contribution workflow

### DIFF
--- a/.github/workflows/expense.yml
+++ b/.github/workflows/expense.yml
@@ -10,7 +10,6 @@ on:
         description: "The expense amount you like to grant for the contribution in $"
         required: true
         type: choice
-        default: "patch"
         options:
           - 15
           - 25

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
           team: technical-steering-committee
           organisation: webdriverio
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WDIO_BOT_GITHUB_TOKEN }}
   release:
     needs: [authorize]
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Proposed Changes

- Remove the `default` value
- Prefer WDIO_BOT_GITHUB_TOKEN over GH_TOKEN
